### PR TITLE
Add text-to-speech option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a Model Context Protocol (MCP) tool that allows Claude to interact with 
 - Ask ChatGPT questions directly from Claude
 - View ChatGPT conversation history
 - Continue existing ChatGPT conversations
+- Optionally have ChatGPT read answers aloud with the `speak` flag
 
 ## Installation
 
@@ -93,6 +94,10 @@ Once installed, you can use the ChatGPT tool directly from Claude by asking ques
 - "Can you ask ChatGPT what the capital of France is?"
 - "Show me my recent ChatGPT conversations"
 - "Ask ChatGPT to explain quantum computing"
+- "Read the latest response aloud":
+  ```json
+  {"operation": "ask", "prompt": "Tell me a joke", "speak": true}
+  ```
 
 ## Troubleshooting
 

--- a/tests/isChatGPTArgs.test.ts
+++ b/tests/isChatGPTArgs.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, mock, spyOn } from "bun:test";
+
+// Mock child_process.exec
+mock.module("child_process", () => ({
+  exec: mock(() => {})
+}));
+
+// Mock run-applescript to always resolve with text
+mock.module("run-applescript", () => ({ runAppleScript: mock(() => Promise.resolve("Hello world")) }));
+
+import * as index from "../index";
+
+// Stub checkChatGPTAccess to avoid real AppleScript
+spyOn(index, "checkChatGPTAccess").mockResolvedValue(true);
+
+describe("isChatGPTArgs", () => {
+  it("accepts speak boolean", () => {
+    const args = { operation: "ask", prompt: "hi", speak: true };
+    expect(index.isChatGPTArgs(args)).toBe(true);
+  });
+
+  it("rejects invalid speak type", () => {
+    const args = { operation: "ask", prompt: "hi", speak: "yes" } as any;
+    expect(index.isChatGPTArgs(args)).toBe(false);
+  });
+});
+
+describe("askChatGPT", () => {
+  it("calls say when speak is true", async () => {
+    const child = await import("child_process");
+    const execSpy = spyOn(child, "exec");
+    const result = await index.askChatGPT("Hi", undefined, true);
+    expect(result).toBe("Hello world");
+    expect(execSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- support speaking responses with new `speak` boolean option
- validate the speak flag
- speak responses via `say` when enabled
- document the new flag
- test argument validation and speech execution

## Testing
- `npm run build`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_683f504590f08328a768a1d3969c3671