### PR TITLE
Add text-to-speech option with error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This is a Model Context Protocol (MCP) tool that allows Claude to interact with 
 - Ask ChatGPT questions directly from Claude
 - View ChatGPT conversation history
 - Continue existing ChatGPT conversations
+- Optionally have ChatGPT read answers aloud with the `speak` flag
 
 ## Installation
 
@@ -93,6 +94,10 @@ Once installed, you can use the ChatGPT tool directly from Claude by asking ques
 - "Can you ask ChatGPT what the capital of France is?"
 - "Show me my recent ChatGPT conversations"
 - "Ask ChatGPT to explain quantum computing"
+- "Read the latest response aloud":
+  ```json
+  {"operation": "ask", "prompt": "Tell me a joke", "speak": true}
+  ```
 
 ## Troubleshooting
 

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { runAppleScript } from "run-applescript";
 import { run } from "@jxa/run";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { fileURLToPath } from "url";
 
 // Define the ChatGPT tool
@@ -256,7 +256,11 @@ async function askChatGPT(
                 }
 
                 if (speak) {
-                        exec(`say ${JSON.stringify(cleanedResult)}`);
+                        execFile("say", [cleanedResult], (error) => {
+                                if (error) {
+                                        console.error("Error during text-to-speech:", error);
+                                }
+                        });
                 }
 
                 return cleanedResult;

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import {
 import { runAppleScript } from "run-applescript";
 import { run } from "@jxa/run";
 import { execFile } from "child_process";
+import { realpathSync } from "node:fs";
 import { fileURLToPath } from "url";
 
 // Define the ChatGPT tool
@@ -473,9 +474,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
 const transport = new StdioServerTransport();
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+function isMainModule(
+	moduleUrl: string,
+	executablePath = process.argv[1],
+): boolean {
+	if (!executablePath) return false;
+
+	try {
+		return (
+			realpathSync(executablePath) ===
+			realpathSync(fileURLToPath(moduleUrl))
+		);
+	} catch {
+		return false;
+	}
+}
+
+if (isMainModule(import.meta.url)) {
         await server.connect(transport);
         console.error("ChatGPT MCP Server running on stdio");
 }
 
-export { askChatGPT, isChatGPTArgs };
+export { askChatGPT, isChatGPTArgs, isMainModule };

--- a/tests/isChatGPTArgs.test.ts
+++ b/tests/isChatGPTArgs.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, mock, spyOn } from "bun:test";
+
+// Mock child_process.exec
+mock.module("child_process", () => ({
+  exec: mock(() => {})
+}));
+
+// Mock run-applescript to always resolve with text
+mock.module("run-applescript", () => ({ runAppleScript: mock(() => Promise.resolve("Hello world")) }));
+
+import * as index from "../index";
+
+// Stub checkChatGPTAccess to avoid real AppleScript
+spyOn(index, "checkChatGPTAccess").mockResolvedValue(true);
+
+describe("isChatGPTArgs", () => {
+  it("accepts speak boolean", () => {
+    const args = { operation: "ask", prompt: "hi", speak: true };
+    expect(index.isChatGPTArgs(args)).toBe(true);
+  });
+
+  it("rejects invalid speak type", () => {
+    const args = { operation: "ask", prompt: "hi", speak: "yes" } as any;
+    expect(index.isChatGPTArgs(args)).toBe(false);
+  });
+});
+
+describe("askChatGPT", () => {
+  it("calls say when speak is true", async () => {
+    const child = await import("child_process");
+    const execSpy = spyOn(child, "exec");
+    const result = await index.askChatGPT("Hi", undefined, true);
+    expect(result).toBe("Hello world");
+    expect(execSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/isChatGPTArgs.test.ts
+++ b/tests/isChatGPTArgs.test.ts
@@ -1,8 +1,18 @@
 import { describe, it, expect, mock, spyOn } from "bun:test";
 
-// Mock child_process.exec
+let speechError: Error | null = null;
+const execFileMock = mock(
+  (
+    _file: string,
+    _args: string[],
+    callback?: (error: Error | null) => void,
+  ) => callback?.(speechError),
+);
+
+// Mock the external text-to-speech process.
 mock.module("child_process", () => ({
-  exec: mock(() => {})
+  exec: mock(() => {}),
+  execFile: execFileMock,
 }));
 
 // Mock run-applescript to always resolve with text
@@ -27,10 +37,30 @@ describe("isChatGPTArgs", () => {
 
 describe("askChatGPT", () => {
   it("calls say when speak is true", async () => {
-    const child = await import("child_process");
-    const execSpy = spyOn(child, "exec");
     const result = await index.askChatGPT("Hi", undefined, true);
     expect(result).toBe("Hello world");
-    expect(execSpy).toHaveBeenCalled();
+    expect(execFileMock).toHaveBeenCalledWith(
+      "say",
+      ["Hello world"],
+      expect.any(Function),
+    );
+  });
+
+  it("reports say failures without failing the ChatGPT response", async () => {
+    speechError = new Error("say unavailable");
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const result = await index.askChatGPT("Hi", undefined, true);
+
+      expect(result).toBe("Hello world");
+      expect(consoleError).toHaveBeenCalledWith(
+        "Error during text-to-speech:",
+        speechError,
+      );
+    } finally {
+      speechError = null;
+      consoleError.mockRestore();
+    }
   });
 });

--- a/tests/isChatGPTArgs.test.ts
+++ b/tests/isChatGPTArgs.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, mock, spyOn } from "bun:test";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 let speechError: Error | null = null;
 const execFileMock = mock(
@@ -22,6 +26,25 @@ import * as index from "../index";
 
 // Stub checkChatGPTAccess to avoid real AppleScript
 spyOn(index, "checkChatGPTAccess").mockResolvedValue(true);
+
+describe("isMainModule", () => {
+  it("recognizes a symlinked executable as the direct entry point", () => {
+    const temporaryDirectory = mkdtempSync(
+      join(tmpdir(), "claude-chatgpt-mcp-entry-"),
+    );
+    const modulePath = fileURLToPath(new URL("../index.ts", import.meta.url));
+    const executablePath = join(temporaryDirectory, "claude-chatgpt-mcp");
+    symlinkSync(modulePath, executablePath);
+
+    try {
+      expect(
+        index.isMainModule(pathToFileURL(modulePath).href, executablePath),
+      ).toBe(true);
+    } finally {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("isChatGPTArgs", () => {
   it("accepts speak boolean", () => {


### PR DESCRIPTION
## Summary

- adds an optional speak flag that reads ChatGPT responses aloud on macOS
- invokes say directly with separated arguments
- logs text-to-speech failures without failing a successful ChatGPT response
- resolves symlinked npm executables before checking the CLI entry point
- documents the option and adds validation and regression coverage

## Testing

- npm run build
- bun test (5 tests passed)
- verified the built CLI connects when launched through a symlink

## Relationship to existing PRs

This replaces PR #7 because the requester account cannot push to its original branch. It intentionally does not include or modify the stacked GitHub Actions changes from PR #10.